### PR TITLE
mrc-3746 turn proxy buffering off for downloads

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -78,6 +78,12 @@ http {
             proxy_pass http://${SERVICE}/;
         }
 
+        location /download/result {
+            proxy_pass http://${SERVICE}/;
+            proxy_buffering off
+            proxy_ignore_headers "X-Accel-Buffering";
+         }
+
         location /news {
             proxy_pass https://reside-ic.github.io/naomi-news;
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -80,7 +80,7 @@ http {
 
         location /download/result {
             proxy_pass http://${SERVICE}/;
-            proxy_buffering off
+            proxy_buffering off;
             proxy_ignore_headers "X-Accel-Buffering";
          }
 


### PR DESCRIPTION
This PR updates hint_proxy, turning off buffer and caching for download endpoints. This should resolve issues with `net::ERR_CONTENT_LENGTH_MISMATCH` https://github.com/mrc-ide/hint/pull/764 being unable to buffer upstream error response.